### PR TITLE
Authorization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules
 jspm_packages
 lib
 .vscode
+.env
 
 # Serverless directories
 .serverless

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "json-schema-to-ts": "^1.5.0",
         "serverless": "^3.29.0",
         "serverless-auto-swagger": "^2.12.0",
+        "serverless-dotenv-plugin": "^6.0.0",
         "serverless-esbuild": "^1.23.3",
         "ts-node": "^10.4.0",
         "tsconfig-paths": "^3.9.0",
@@ -13536,6 +13537,20 @@
       },
       "peerDependencies": {
         "serverless": "^2 || ^3"
+      }
+    },
+    "node_modules/serverless-dotenv-plugin": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serverless-dotenv-plugin/-/serverless-dotenv-plugin-6.0.0.tgz",
+      "integrity": "sha512-8tLVNwHfDO0sBz6+m+DLTZquRk0AZq9rzqk3kphm1iIWKfan9R7RKt4hdq3eQ0kmDoqzudjPYBEXAJ5bUNKeGQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "dotenv": "^16.0.3",
+        "dotenv-expand": "^10.0.0"
+      },
+      "peerDependencies": {
+        "serverless": "1 || 2 || pre-3 || 3"
       }
     },
     "node_modules/serverless-esbuild": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "json-schema-to-ts": "^1.5.0",
     "serverless": "^3.29.0",
     "serverless-auto-swagger": "^2.12.0",
+    "serverless-dotenv-plugin": "^6.0.0",
     "serverless-esbuild": "^1.23.3",
     "ts-node": "^10.4.0",
     "tsconfig-paths": "^3.9.0",

--- a/serverless.ts
+++ b/serverless.ts
@@ -25,6 +25,9 @@ const serverlessConfiguration: AWS = {
       minimumCompressionSize: 1024,
       shouldStartNameWithService: true,
     },
+    httpApi: {
+      cors: true,
+    },
     iam: {
       role: {
         statements: [
@@ -91,6 +94,66 @@ const serverlessConfiguration: AWS = {
           Endpoint: "mrinex@mail.ru",
           Protocol: "email",
           TopicArn: { Ref: "createProductTopic" },
+        },
+      },
+      GatewayResponseAccessDenied: {
+        Type: "AWS::ApiGateway::GatewayResponse",
+        Properties: {
+          ResponseParameters: {
+            "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+            "gatewayresponse.header.Access-Control-Allow-Headers": "'*'",
+            "gatewayresponse.header.Access-Control-Allow-Methods":
+              "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
+          },
+          ResponseType: "ACCESS_DENIED",
+          RestApiId: {
+            Ref: "ApiGatewayRestApi",
+          },
+        },
+      },
+      GatewayResponseUnauthorized: {
+        Type: "AWS::ApiGateway::GatewayResponse",
+        Properties: {
+          ResponseParameters: {
+            "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+            "gatewayresponse.header.Access-Control-Allow-Headers": "'*'",
+            "gatewayresponse.header.Access-Control-Allow-Methods":
+              "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
+          },
+          ResponseType: "UNAUTHORIZED",
+          RestApiId: {
+            Ref: "ApiGatewayRestApi",
+          },
+        },
+      },
+      GatewayResponseDefault5XX: {
+        Type: "AWS::ApiGateway::GatewayResponse",
+        Properties: {
+          ResponseParameters: {
+            "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+            "gatewayresponse.header.Access-Control-Allow-Headers": "'*'",
+            "gatewayresponse.header.Access-Control-Allow-Methods":
+              "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
+          },
+          ResponseType: "DEFAULT_5XX",
+          RestApiId: {
+            Ref: "ApiGatewayRestApi",
+          },
+        },
+      },
+      GatewayResponseDefault4XX: {
+        Type: "AWS::ApiGateway::GatewayResponse",
+        Properties: {
+          ResponseParameters: {
+            "gatewayresponse.header.Access-Control-Allow-Origin": "'*'",
+            "gatewayresponse.header.Access-Control-Allow-Headers": "'*'",
+            "gatewayresponse.header.Access-Control-Allow-Methods":
+              "'DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT'",
+          },
+          ResponseType: "DEFAULT_4XX",
+          RestApiId: {
+            Ref: "ApiGatewayRestApi",
+          },
         },
       },
     },

--- a/serverless.ts
+++ b/serverless.ts
@@ -6,11 +6,16 @@ import createProduct from "./src/functions/createProduct";
 import importProductsFile from "./src/functions/importProductsFile";
 import importFileParser from "./src/functions/importFileParser";
 import catalogBatchProcess from "./src/functions/catalogBatchProcess";
+import basicAuthorizer from "./src/functions/basicAuthorizer";
 
 const serverlessConfiguration: AWS = {
   service: "store-backend",
   frameworkVersion: "3",
-  plugins: ["serverless-esbuild", "serverless-auto-swagger"],
+  plugins: [
+    "serverless-esbuild",
+    "serverless-auto-swagger",
+    "serverless-dotenv-plugin",
+  ],
   provider: {
     name: "aws",
     runtime: "nodejs18.x",
@@ -98,6 +103,7 @@ const serverlessConfiguration: AWS = {
     importProductsFile,
     importFileParser,
     catalogBatchProcess,
+    basicAuthorizer,
   },
   package: { individually: true },
   custom: {

--- a/src/functions/basicAuthorizer/handler.test.ts
+++ b/src/functions/basicAuthorizer/handler.test.ts
@@ -1,0 +1,44 @@
+import { ValidatedAPIGatewayProxyEvent } from "../../libs/api-gateway";
+import { Callback, Context } from "aws-lambda";
+import { basicAuthorizer } from "./handler";
+
+const mock = {
+  success: {
+    headers: {
+      "Access-Control-Allow-Credentials": true,
+      "Access-Control-Allow-Origin": "*",
+    },
+    statusCode: 200,
+  },
+  product: {},
+};
+
+jest.mock("../../libs/productService", () => {
+  return {
+    getDdbTransactProductService: () => ({
+      putTransact: () => [],
+    }),
+  };
+});
+
+describe("basicAuthorizer", () => {
+  test("should return product by id", async () => {
+    const event = {} as ValidatedAPIGatewayProxyEvent<undefined>;
+    const context = <Context>{};
+    const callback: Callback = () => {};
+
+    mock.product = {
+      id: "1",
+      title: "rew",
+      description: "jet",
+      price: 33,
+      image: "http//sd",
+    };
+
+    const response = await basicAuthorizer(event, context, callback);
+    expect(response).toMatchObject({
+      ...mock.success,
+      body: JSON.stringify({ data: [], message: "products" }),
+    });
+  });
+});

--- a/src/functions/basicAuthorizer/handler.ts
+++ b/src/functions/basicAuthorizer/handler.ts
@@ -1,10 +1,34 @@
 import { middyfy } from "../../libs/lambda";
-import { APIGatewayAuthorizerHandler } from "aws-lambda/trigger/api-gateway-authorizer"; // APIGatewayRequestSimpleAuthorizerHandlerV2,
+import { APIGatewayRequestAuthorizerHandler } from "aws-lambda/trigger/api-gateway-authorizer";
+import { Unauthorized, Forbidden } from "http-errors";
 
-export const basicAuthorizer: APIGatewayAuthorizerHandler = async (event) => {
-  // console.log(JSON.stringify(event, null, 2));
+export const basicAuthorizer: APIGatewayRequestAuthorizerHandler = async (
+  event
+) => {
+  const { Authorization } = event.headers;
+  if (!Authorization) {
+    throw Unauthorized();
+  }
 
-  // return { isAuthorized: true };
+  const utf8Password = Buffer.from(
+    Authorization.replace("Basic ", ""),
+    "base64"
+  ).toString("utf8");
+  const [user, password] = utf8Password.split(":");
+  const isValid = process.env.mrinex === password;
+
+  console.log({
+    mrinex: process.env.mrinex,
+    utf8Password,
+    password,
+    user,
+    isValid,
+  });
+
+  if (!isValid) {
+    throw Forbidden();
+  }
+
   return {
     principalId: "user",
     policyDocument: {
@@ -19,5 +43,11 @@ export const basicAuthorizer: APIGatewayAuthorizerHandler = async (event) => {
     },
   };
 };
+
+// Buffer.from("TEST_PASSWORD").toString("base64");
+// ("VEVTVF9QQVNTV09SRA==");
+
+// Buffer.from("VEVTVF9QQVNTV09SRA==", "base64").toString("utf8");
+// ("TEST_PASSWORD");
 
 export const main = middyfy(basicAuthorizer, false);

--- a/src/functions/basicAuthorizer/handler.ts
+++ b/src/functions/basicAuthorizer/handler.ts
@@ -3,13 +3,11 @@ import { APIGatewayRequestAuthorizerHandler } from "aws-lambda/trigger/api-gatew
 import { Unauthorized, Forbidden } from "http-errors";
 
 export const basicAuthorizer: APIGatewayRequestAuthorizerHandler = async (
-  event,
-  _context,
-  cb
+  event
 ) => {
   const { Authorization } = event.headers;
   if (!Authorization) {
-    cb(Unauthorized());
+    throw Unauthorized();
   }
 
   const utf8Password = Buffer.from(
@@ -28,7 +26,7 @@ export const basicAuthorizer: APIGatewayRequestAuthorizerHandler = async (
   });
 
   if (!isValid) {
-    cb(Forbidden());
+    throw Forbidden();
   }
 
   return {

--- a/src/functions/basicAuthorizer/handler.ts
+++ b/src/functions/basicAuthorizer/handler.ts
@@ -1,14 +1,10 @@
 import { middyfy } from "../../libs/lambda";
 import { APIGatewayRequestAuthorizerHandler } from "aws-lambda/trigger/api-gateway-authorizer";
-import { Unauthorized, Forbidden } from "http-errors";
 
 export const basicAuthorizer: APIGatewayRequestAuthorizerHandler = async (
   event
 ) => {
   const { Authorization } = event.headers;
-  if (!Authorization) {
-    throw Unauthorized();
-  }
 
   const utf8Password = Buffer.from(
     Authorization.replace("Basic ", ""),
@@ -25,10 +21,6 @@ export const basicAuthorizer: APIGatewayRequestAuthorizerHandler = async (
     isValid,
   });
 
-  if (!isValid) {
-    throw Forbidden();
-  }
-
   return {
     principalId: "user",
     policyDocument: {
@@ -36,7 +28,7 @@ export const basicAuthorizer: APIGatewayRequestAuthorizerHandler = async (
       Statement: [
         {
           Action: "execute-api:Invoke",
-          Effect: "Allow",
+          Effect: isValid ? "Allow" : "Deny",
           Resource: event.methodArn,
         },
       ],

--- a/src/functions/basicAuthorizer/handler.ts
+++ b/src/functions/basicAuthorizer/handler.ts
@@ -1,0 +1,23 @@
+import { middyfy } from "../../libs/lambda";
+import { APIGatewayAuthorizerHandler } from "aws-lambda/trigger/api-gateway-authorizer"; // APIGatewayRequestSimpleAuthorizerHandlerV2,
+
+export const basicAuthorizer: APIGatewayAuthorizerHandler = async (event) => {
+  // console.log(JSON.stringify(event, null, 2));
+
+  // return { isAuthorized: true };
+  return {
+    principalId: "user",
+    policyDocument: {
+      Version: "2012-10-17",
+      Statement: [
+        {
+          Action: "execute-api:Invoke",
+          Effect: "Allow",
+          Resource: event.methodArn,
+        },
+      ],
+    },
+  };
+};
+
+export const main = middyfy(basicAuthorizer, false);

--- a/src/functions/basicAuthorizer/handler.ts
+++ b/src/functions/basicAuthorizer/handler.ts
@@ -3,11 +3,13 @@ import { APIGatewayRequestAuthorizerHandler } from "aws-lambda/trigger/api-gatew
 import { Unauthorized, Forbidden } from "http-errors";
 
 export const basicAuthorizer: APIGatewayRequestAuthorizerHandler = async (
-  event
+  event,
+  _context,
+  cb
 ) => {
   const { Authorization } = event.headers;
   if (!Authorization) {
-    throw Unauthorized();
+    cb(Unauthorized());
   }
 
   const utf8Password = Buffer.from(
@@ -26,7 +28,7 @@ export const basicAuthorizer: APIGatewayRequestAuthorizerHandler = async (
   });
 
   if (!isValid) {
-    throw Forbidden();
+    cb(Forbidden());
   }
 
   return {

--- a/src/functions/basicAuthorizer/index.ts
+++ b/src/functions/basicAuthorizer/index.ts
@@ -1,0 +1,9 @@
+import type { AWS } from "@serverless/typescript";
+import { handlerPath } from "../../libs/handler-resolver";
+
+export default <AWS["functions"]>{
+  handler: `${handlerPath(__dirname)}/handler.main`,
+  environment: {
+    name: process.env.mrinex,
+  },
+};

--- a/src/functions/basicAuthorizer/mock.json
+++ b/src/functions/basicAuthorizer/mock.json
@@ -1,0 +1,6 @@
+{
+  "headers": {
+    "Content-Type": "application/json"
+  },
+  "body": "{\"name\": \"Frederic\"}"
+}

--- a/src/functions/importProductsFile/index.ts
+++ b/src/functions/importProductsFile/index.ts
@@ -16,6 +16,12 @@ export default <AWS["functions"]>{
           },
           502: "Server error",
         },
+        authorizer: {
+          name: "basicAuthorizer",
+          resultTtlInSeconds: 0,
+          type: "request",
+          // arn: "arn:aws:lambda:us-east-1:888972506066:function:store-backend-dev-basicAuthorizer",
+        },
       },
     },
   ],

--- a/src/functions/importProductsFile/index.ts
+++ b/src/functions/importProductsFile/index.ts
@@ -8,7 +8,7 @@ export default <AWS["functions"]>{
       http: {
         method: "get",
         path: "import",
-        cors: { origin: "*" },
+        cors: true,
         responses: {
           200: {
             description: "file",
@@ -20,7 +20,7 @@ export default <AWS["functions"]>{
           name: "basicAuthorizer",
           resultTtlInSeconds: 0,
           identitySource: "method.request.header.Authorization",
-          type: "request",
+          type: "REQUEST",
           // enableSimpleResponses: true,
           // payloadVersion: "2.0",
           // arn: "arn:aws:lambda:us-east-1:888972506066:function:store-backend-dev-basicAuthorizer",

--- a/src/functions/importProductsFile/index.ts
+++ b/src/functions/importProductsFile/index.ts
@@ -8,7 +8,7 @@ export default <AWS["functions"]>{
       http: {
         method: "get",
         path: "import",
-        cors: true,
+        cors: { origin: "*" },
         responses: {
           200: {
             description: "file",
@@ -19,6 +19,7 @@ export default <AWS["functions"]>{
         authorizer: {
           name: "basicAuthorizer",
           resultTtlInSeconds: 0,
+          identitySource: "method.request.header.Authorization",
           type: "request",
           // arn: "arn:aws:lambda:us-east-1:888972506066:function:store-backend-dev-basicAuthorizer",
         },

--- a/src/functions/importProductsFile/index.ts
+++ b/src/functions/importProductsFile/index.ts
@@ -21,6 +21,8 @@ export default <AWS["functions"]>{
           resultTtlInSeconds: 0,
           identitySource: "method.request.header.Authorization",
           type: "request",
+          // enableSimpleResponses: true,
+          // payloadVersion: "2.0",
           // arn: "arn:aws:lambda:us-east-1:888972506066:function:store-backend-dev-basicAuthorizer",
         },
       },

--- a/src/functions/index.ts
+++ b/src/functions/index.ts
@@ -4,3 +4,4 @@ export { default as createProduct } from "./createProduct";
 export { default as importProductsFile } from "./importProductsFile";
 export { default as importFileParser } from "./importFileParser";
 export { default as catalogBatchProcess } from "./catalogBatchProcess";
+export { default as basicAuthorizer } from "./basicAuthorizer";


### PR DESCRIPTION
Authorization
Task 7

```
Result 100%.
I have implemented all criterias.
I attached screenshots for your more comfortable review.
Thank you in advance

endpoints:
  GET - https://4ws13igcqj.execute-api.us-east-1.amazonaws.com/swagger
  GET - https://4ws13igcqj.execute-api.us-east-1.amazonaws.com/swagger.json
  GET - https://zbmoh4gs7i.execute-api.us-east-1.amazonaws.com/dev/products
  GET - https://zbmoh4gs7i.execute-api.us-east-1.amazonaws.com/dev/products/{id}
  POST - https://zbmoh4gs7i.execute-api.us-east-1.amazonaws.com/dev/products
  GET - https://zbmoh4gs7i.execute-api.us-east-1.amazonaws.com/dev/import
functions:
  getProducts: store-backend-dev-getProducts (2.4 MB)
  getProduct: store-backend-dev-getProduct (2.5 MB)
  createProduct: store-backend-dev-createProduct (2.4 MB)
  importProductsFile: store-backend-dev-importProductsFile (1.8 MB)
  importFileParser: store-backend-dev-importFileParser (1.8 MB)
  catalogBatchProcess: store-backend-dev-catalogBatchProcess (2.7 MB)
  basicAuthorizer: store-backend-dev-basicAuthorizer (32 kB)
  swaggerUI: store-backend-dev-swagger-ui (2.6 kB)
  swaggerJSON: store-backend-dev-swagger-json (3.6 kB)
```
It is link to deployed [APP](https://d267d8ijc3bl1b.cloudfront.net/) - https://d267d8ijc3bl1b.cloudfront.net/

Evaluation criteria +70
- [x] authorization-service is added to the repo, has correct basicAuthorizer lambda and correct serverless.yaml file
  <img width="632" alt="Screenshot 2023-04-29 at 00 30 52" src="https://user-images.githubusercontent.com/35580404/235257633-afa757a5-95ad-4cab-8c24-d741815ff2c5.png">
  <img width="416" alt="Screenshot 2023-04-29 at 00 30 02" src="https://user-images.githubusercontent.com/35580404/235257659-424be147-ae99-4f3e-a4d8-256578ea160e.png">
- [x] Import Service serverless.yaml file has authorizer configuration for the importProductsFile lambda. Request to the importProductsFile lambda should work only with correct authorization_token being decoded and checked by basicAuthorizer lambda. Response should be in 403 HTTP status if access is denied for this user (invalid authorization_token) and in 401 HTTP status if Authorization header is not provided.
  <img width="822" alt="Screenshot 2023-04-29 at 00 33 36" src="https://user-images.githubusercontent.com/35580404/235258087-89b47c56-72a4-4999-8d4e-8a5bf2ae9e39.png">
  <img width="820" alt="Screenshot 2023-04-29 at 00 33 51" src="https://user-images.githubusercontent.com/35580404/235258098-5e186a89-e40b-44ac-8d2c-14e1694d4e4a.png">
  <img width="820" alt="Screenshot 2023-04-29 at 00 34 02" src="https://user-images.githubusercontent.com/35580404/235258123-9164a5ae-166c-4116-a83e-18d8c71fa9e5.png">
- [x] Client application is updated to send "Authorization: Basic authorization_token" header on import. Client should get authorization_token value from browser [localStorage](https://developer.mozilla.org/ru/docs/Web/API/Window/localStorage)
  **Front-end PR with changes is https://github.com/mrINEX/store-frontend/pull/4**
  <img width="461" alt="Screenshot 2023-04-29 at 00 37 02" src="https://user-images.githubusercontent.com/35580404/235258439-2f0b7b64-719f-4a22-90de-55f9ba9bc1fa.png">

Additional tasks +30

- [x] Client application should display alerts for the responses in 401 and 403 HTTP statuses.
  Front-end PR with changes is https://github.com/mrINEX/store-frontend/pull/4
  <img width="536" alt="Screenshot 2023-04-29 at 20 58 04" src="https://user-images.githubusercontent.com/35580404/235317261-0ce93ce9-104e-4f42-b053-ca301aa6fc9a.png">

Total: 100%